### PR TITLE
Update adventure-platform-fabric to 5.2.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,11 +7,11 @@ loader_version=0.13.3
 fabric_version=0.48.0+1.18.2
 
 # Mod Properties
-mod_version = 2.0.1
+mod_version = 2.0.2
 maven_group = net.emc.emce
 name = EarthMCEssentials
 
 # Library versions
 cloth_config_version = 6.2.57
 mod_menu_version = 3.1.0
-adventure_fabric_version = 5.2.0
+adventure_fabric_version = 5.2.1


### PR DESCRIPTION
This version update should fix the crashes related to Fabric Loader version compatibility. Patch notes for reference: https://github.com/KyoriPowered/adventure-platform-fabric/releases/tag/v5.2.1
Previous version crashing:
![image](https://user-images.githubusercontent.com/106488708/170932025-891d1202-acea-4cf6-b07c-225d8f41c033.png)

New version working:
![image](https://user-images.githubusercontent.com/106488708/170932041-79725644-c26a-4479-bbe9-ef0a6ce4f453.png)
